### PR TITLE
feat: add 'gitflow' alias to run flow everywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ RUN poetry config virtualenvs.create false && \
 
 COPY . /app/
 
+RUN echo 'alias gitflow="python /app/main.py"' >> ~/.bashrc
+
 ENTRYPOINT ["python", "main.py"]


### PR DESCRIPTION
Gitlab overrides default entrypoint to run runner with a shell inside repository cloned folder, an alias may help to run flow commands from anywhere inside container.