### PR TITLE
docs: improve documentation for CLI

### DIFF
--- a/gitflow_toolbox/check_branch_exists.py
+++ b/gitflow_toolbox/check_branch_exists.py
@@ -7,15 +7,25 @@ from gitflow_toolbox.common.is_main_call import is_main_call
 
 
 @click.command()
-@click.option("--remote/--current", default=False)
 @click.argument("branch", type=str)
+@click.option(
+    "--remote/--current",
+    "-r/-c",
+    default=False,
+    help="Flag which allow you to chose between configured target or remote to run this tool."
+    " By default, the script use --current flag.",
+)
 @click.pass_context
-def check_branch_exists(ctx: click.Context, remote: bool, branch: str):
-    """Checks if a branch exists
+def check_branch_exists(ctx: click.Context, branch: str, remote: bool = False):
+    """Checks if the given BRANCH exists
+
+    Return True if a branch exists (exit code 0), False otherwise (exit code 1)
+    \f
 
     Args:
-        remote (bool): whether to check on the current gitlab or remote gitlab (True=remote)
         branch (str): branch name
+        remote (bool, optional):
+            whether to check on the current gitlab or remote gitlab (True=remote). Default to False.
 
     Returns:
         bool: True if branch exists (exit code 0), False otherwise (exit code 1)

--- a/gitflow_toolbox/check_mr_exists.py
+++ b/gitflow_toolbox/check_mr_exists.py
@@ -7,25 +7,45 @@ from gitflow_toolbox.common.is_main_call import is_main_call
 
 
 @click.command()
-@click.option("--remote/--current", default=False)
 @click.argument("source_branch", type=str)
 @click.argument("target_branch", type=str)
-@click.option("--state", type=str, default="opened")
+@click.option(
+    "--remote/--current",
+    "-r/-c",
+    default=False,
+    help="Flag which allow you to chose between configured target or remote to run this tool."
+    " By default, the script use --current flag.",
+)
+@click.option(
+    "--state",
+    "-s",
+    type=click.Choice(["opened", "closed", "locked", "merged"], case_sensitive=False),
+    default="opened",
+    help="Flag which allow you to filter merge request during search if it exists by the given state."
+    " By default to 'opened'.",
+)
 @click.pass_context
-def check_mr_exists(ctx: click.Context, remote: bool, source_branch: str, target_branch: str, state: str):
-    """Check if a MR exists
+def check_mr_exists(
+    ctx: click.Context, source_branch: str, target_branch: str, remote: bool = False, state: str = "opened"
+):
+    """Check if the merge request between SOURCE_BRANCH and TARGET_BRANCH exists
+
+    Return True if a MR exists (exit code 0), False otherwise (exit code 1)
+    \f
 
     Args:
-        remote (bool): whether to check on the current gitlab or remote gitlab (True=remote)
         source_branch (str): branch to create
         remote_target_branch (str): branch reference to create branch from
+        remote (bool, optional):
+            whether to check on the current gitlab or remote gitlab (True=remote). Defaults to False.
+        state (str, optional): The state of the merge request expected. Defaults to "opened".
 
     Returns:
         bool: True if a MR exists (exit code 0), False otherwise (exit code 1)
     """
     click.echo(f"Checking if an opened merge request from {source_branch} to {target_branch} exists...")
     project = RemoteGitlab().project if remote else CurrentGitlab().project
-    mrs = project.mergerequests.list(state=state, source_branch=source_branch, target_branch=target_branch)
+    mrs = project.mergerequests.list(state=state.lower(), source_branch=source_branch, target_branch=target_branch)
     mr_exists = len(mrs) != 0
     if is_main_call(ctx):
         click.echo(mr_exists)

--- a/gitflow_toolbox/diff.py
+++ b/gitflow_toolbox/diff.py
@@ -10,25 +10,37 @@ from gitflow_toolbox.common.is_main_call import is_main_call
 
 
 @click.command()
-@click.option("--from-gitlab", type=click.Choice(["current", "remote"], case_sensitive=False))
 @click.argument("source_branch", type=str)
-@click.option("--to-gitlab", type=click.Choice(["current", "remote"], case_sensitive=False))
 @click.argument("target_branch", type=str)
+@click.option(
+    "--from-gitlab",
+    "-f",
+    type=click.Choice(["current", "remote"], case_sensitive=False),
+    help="Flag which allow you to chose between the current gitlab or the remote gitlab for the FROM role of the diff."
+    " Defaults to 'remote'.",
+)
+@click.option(
+    "--to-gitlab",
+    "-t",
+    type=click.Choice(["current", "remote"], case_sensitive=False),
+    help="Flag which allow you to chose between the current gitlab or the remote gitlab for the TO role of the diff."
+    " Defaults to 'remote'.",
+)
 @click.pass_context
 def diff(
     ctx: click.Context,
-    from_gitlab: tuple[str],
     source_branch: str,
-    to_gitlab: tuple[str],
     target_branch: str,
+    from_gitlab: str = "remote",
+    to_gitlab: str = "remote",
 ):
-    """Returns the 'git diff' between two branches
+    """Returns the 'git diff' between SOURCE_BRANCH and TARGET_BRANCH\f
 
     Args:
-        from_gitlab (str): source gitlab [current/remote]
         source_branch (str): source branch
-        to_gitlab (str): destination gitlab [current/remote]
         target_branch (str): destination branch
+        from_gitlab (str, optional): source gitlab [current/remote]. Defaults to "remote".
+        to_gitlab (str, optional): destination gitlab [current/remote]. Defaults to "remote".
 
     Returns:
         str: the 'git diff' between two branches, or an empty string (line return) if no diff

--- a/gitflow_toolbox/ensure_branch.py
+++ b/gitflow_toolbox/ensure_branch.py
@@ -5,17 +5,24 @@ from gitflow_toolbox.common.gitlab import CurrentGitlab, RemoteGitlab
 
 
 @click.command()
-@click.option("--remote/--current", default=False)
 @click.argument("branch", type=str)
 @click.argument("ref", type=str)
+@click.option(
+    "--remote/--current",
+    "-r/-c",
+    default=False,
+    help="Flag which allow you to chose between configured target or remote to run this tool."
+    " By default, the script use --current flag.",
+)
 @click.pass_context
-def ensure_branch(ctx: click.Context, remote: bool, branch: str, ref: str):
-    """Creates a branch if doesn't exist
+def ensure_branch(ctx: click.Context, branch: str, ref: str, remote: bool = False):
+    """Creates the branch BRANCH using branch REF if the target doesn't exist\f
 
     Args:
-        remote (bool): whether to check on the current gitlab or remote gitlab (True=remote)
         branch (str): branch name
         ref (str): branch to create branch from
+        remote (bool, optional):
+            whether to check on the current gitlab or remote gitlab (True=remote). Default to False.
     """
 
     branch_exists = ctx.invoke(check_branch_exists, remote=remote, branch=branch)

--- a/gitflow_toolbox/get_latest_mr_state.py
+++ b/gitflow_toolbox/get_latest_mr_state.py
@@ -5,19 +5,28 @@ from gitflow_toolbox.common.is_main_call import is_main_call
 
 
 @click.command()
-@click.option("--remote/--current", default=False)
 @click.argument("source_branch", type=str)
 @click.argument("target_branch", type=str)
 @click.argument("labels", type=str, nargs=-1)
+@click.option(
+    "--remote/--current",
+    "-r/-c",
+    default=False,
+    help="Flag which allow you to chose between configured target or remote to run this tool."
+    " By default, the script use --current flag.",
+)
 @click.pass_context
-def get_latest_mr_state(ctx: click.Context, remote: bool, source_branch: str, target_branch: str, labels: tuple[str]):
-    """Returns the state of the latest MR from/to branch
+def get_latest_mr_state(
+    ctx: click.Context, source_branch: str, target_branch: str, labels: tuple[str], remote: bool = False
+):
+    """Returns the state of the latest merge request between SOURCE_BRANCH and TARGET_BRANCH\f
 
     Args:
-        remote (bool): whether to check on the current gitlab or remote gitlab (True=remote)
         source_branch (str): branch to create
         remote_target_branch (str): branch reference to create branch from
         labels (tuple[str]): filter by labels
+        remote (bool, optional):
+            whether to check on the current gitlab or remote gitlab (True=remote). Default to False.
 
     Returns:
         str: state of the latest MR (opened/closed/merged/locked) or 'no-mr' if nothing was found

--- a/gitflow_toolbox/get_project_http_url.py
+++ b/gitflow_toolbox/get_project_http_url.py
@@ -5,13 +5,20 @@ from gitflow_toolbox.common.is_main_call import is_main_call
 
 
 @click.command()
-@click.option("--remote/--current", default=False)
+@click.option(
+    "--remote/--current",
+    "-r/-c",
+    default=False,
+    help="Flag which allow you to chose between configured target or remote to run this tool."
+    " By default, the script use --current flag.",
+)
 @click.pass_context
-def get_project_http_url(ctx: click.Context, remote: bool):
-    """Get Gitlab project SSH URL (for cloning)
+def get_project_http_url(ctx: click.Context, remote: bool = False):
+    """Get Gitlab project SSH URL (for cloning)\f
 
     Args:
-        remote (bool): whether to check on the current gitlab or remote gitlab (True=remote)
+        remote (bool, optional):
+            whether to check on the current gitlab or remote gitlab (True=remote). Default to False.
     """
     project = RemoteGitlab().project if remote else CurrentGitlab().project
     url = project.attributes.get("http_url_to_repo")

--- a/gitflow_toolbox/get_project_ssh_url.py
+++ b/gitflow_toolbox/get_project_ssh_url.py
@@ -5,13 +5,20 @@ from gitflow_toolbox.common.is_main_call import is_main_call
 
 
 @click.command()
-@click.option("--remote/--current", default=False)
+@click.option(
+    "--remote/--current",
+    "-r/-c",
+    default=False,
+    help="Flag which allow you to chose between configured target or remote to run this tool."
+    " By default, the script use --current flag.",
+)
 @click.pass_context
-def get_project_ssh_url(ctx: click.Context, remote: bool):
-    """Get Gitlab project SSH URL (for cloning)
+def get_project_ssh_url(ctx: click.Context, remote: bool = False):
+    """Get Gitlab project SSH URL (for cloning)\f
 
     Args:
-        remote (bool): whether to check on the current gitlab or remote gitlab (True=remote)
+        remote (bool, optional):
+            whether to check on the current gitlab or remote gitlab (True=remote). Default to False.
     """
     project = RemoteGitlab().project if remote else CurrentGitlab().project
     ssh_url = project.attributes.get("ssh_url_to_repo")

--- a/gitflow_toolbox/push.py
+++ b/gitflow_toolbox/push.py
@@ -11,29 +11,43 @@ from gitflow_toolbox.get_project_http_url import get_project_http_url
 
 
 @click.command()
-@click.option("--from-gitlab", type=click.Choice(["current", "remote"], case_sensitive=False))
 @click.argument("source_branch", type=str)
-@click.option("--to-gitlab", type=click.Choice(["current", "remote"], case_sensitive=False))
 @click.argument("target_branch", type=str)
-@click.option("--force", is_flag=True, type=bool)
+@click.option(
+    "--from-gitlab",
+    "-f",
+    type=click.Choice(["current", "remote"], case_sensitive=False),
+    help="Flag which allow you to chose between the current gitlab or the remote gitlab for the FROM role."
+    " Defaults to 'remote'.",
+)
+@click.option(
+    "--to-gitlab",
+    "-t",
+    type=click.Choice(["current", "remote"], case_sensitive=False),
+    help="Flag which allow you to chose between the current gitlab or the remote gitlab for the TO role."
+    " Defaults to 'remote'.",
+)
+@click.option("--force", "-f", is_flag=True, type=bool, help="Flag to enable force push")
 @click.pass_context
 def push(
     ctx: click.Context,
-    from_gitlab: tuple[str],
     source_branch: str,
-    to_gitlab: tuple[str],
     target_branch: str,
-    force: bool,
+    from_gitlab: str = "remote",
+    to_gitlab: str = "remote",
+    force: bool = False,
 ):
-    """Push commits from a branch to another branch
+    """Push commits from SOURCE_BRANCH to TARGET_BRANCH\f
 
     Args:
-        from_gitlab (str): source gitlab [current/remote]
         source_branch (str): source branch
-        to_gitlab (str): destination gitlab [current/remote]
         target_branch (str): destination branch
-        force (bool): whether to force push (default: False)
+        from_gitlab (str, optional): source gitlab [current/remote]. Defaults to 'remote'.
+        to_gitlab (str, optional): destination gitlab [current/remote]. Defaults to 'remote'.
+        force (bool, optional): whether to force push. Defaults to False.
     """
+    to_gitlab = to_gitlab.lower()
+    from_gitlab = from_gitlab.lower()
 
     gitlab_from = CurrentGitlab() if from_gitlab == "current" else RemoteGitlab()
     gitlab_to = CurrentGitlab() if to_gitlab == "current" else RemoteGitlab()

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from gitflow_toolbox.check_mr_exists import check_mr_exists
 from gitflow_toolbox.diff import diff
 from gitflow_toolbox.ensure_branch import ensure_branch
 from gitflow_toolbox.ensure_mr import ensure_mr
+from gitflow_toolbox.get_latest_mr_state import get_latest_mr_state
 from gitflow_toolbox.get_project_http_url import get_project_http_url
 from gitflow_toolbox.get_project_ssh_url import get_project_ssh_url
 from gitflow_toolbox.push import push
@@ -23,6 +24,7 @@ cli.add_command(check_branch_exists)
 cli.add_command(ensure_branch)
 cli.add_command(check_mr_exists)
 cli.add_command(ensure_mr)
+cli.add_command(get_latest_mr_state)
 cli.add_command(get_project_ssh_url)
 cli.add_command(get_project_http_url)
 cli.add_command(push)


### PR DESCRIPTION
Improve documentation for CLI

Samples:

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py check-branch-exists --help
Usage: main.py check-branch-exists [OPTIONS] BRANCH

  Checks if the given BRANCH exists

  Return True if a branch exists (exit code 0), False otherwise (exit code 1)

Options:
  -r, --remote / -c, --current  Flag which allow you to chose between
                                configured target or remote to run this tool.
                                By default, the script use --current flag.
  --help                        Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py check-mr-exists --help
Usage: main.py check-mr-exists [OPTIONS] SOURCE_BRANCH TARGET_BRANCH

  Check if the merge request between SOURCE_BRANCH and TARGET_BRANCH exists

  Return True if a MR exists (exit code 0), False otherwise (exit code 1)

Options:
  -r, --remote / -c, --current    Flag which allow you to chose between
                                  configured target or remote to run this
                                  tool. By default, the script use --current
                                  flag.
  -s, --state [opened|closed|locked|merged]
                                  Flag which allow you to filter merge request
                                  during search if it exists by the given
                                  state. By default to 'opened'.
  --help                          Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py diff --help
Usage: main.py diff [OPTIONS] SOURCE_BRANCH TARGET_BRANCH

  Returns the 'git diff' between SOURCE_BRANCH and TARGET_BRANCH

Options:
  -f, --from-gitlab [current|remote]
                                  Flag which allow you to chose between the
                                  current gitlab or the remote gitlab for the
                                  FROM role of the diff. Defaults to 'remote'.
  -t, --to-gitlab [current|remote]
                                  Flag which allow you to chose between the
                                  current gitlab or the remote gitlab for the
                                  TO role of the diff. Defaults to 'remote'.
  --help                          Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py ensure-branch --help
Usage: main.py ensure-branch [OPTIONS] BRANCH REF

  Creates the branch BRANCH using branch REF if the target doesn't exist

Options:
  -r, --remote / -c, --current  Flag which allow you to chose between
                                configured target or remote to run this tool.
                                By default, the script use --current flag.
  --help                        Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py ensure-mr --help
Usage: main.py ensure-mr [OPTIONS] SOURCE_BRANCH TARGET_BRANCH TITLE
                         DESCRIPTION [LABELS]...

  Create a merge request from SOURCE_BRANCH to TARGET_BRANCH if not exists
  using given TITLE and DESCRIPTION

Options:
  -ksb, --keep-source-branch    Flag used to specify that you want to keep the
                                source branch once the merge request has been
                                accepted
  -s, --squash                  Flag used to specify that you want to squash
                                commit when the merge request is accepted.
                                This is an option of Gitlab which could be
                                manually deactivated by user after the merge
                                request creation.
  -r, --remote / -c, --current  Flag which allow you to chose between
                                configured target or remote to run this tool.
                                By default, the script use --current flag.
  -ai, --assignee_ids INTEGER   Flag (accepting multiple values) used to
                                specify the assignee IDs to set while creating
                                the merge request.
  -ri, --reviewer_ids INTEGER   Flag (accepting multiple values) used to
                                specify the reviewer IDs to set while creating
                                the merge request.
  --help                        Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py --help
Usage: main.py [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  check-branch-exists   Checks if the given BRANCH exists
  check-mr-exists       Check if the merge request between SOURCE_BRANCH...
  diff                  Returns the 'git diff' between SOURCE_BRANCH and...
  ensure-branch         Creates the branch BRANCH using branch REF if the...
  ensure-mr             Create a merge request from SOURCE_BRANCH to...
  get-latest-mr-state   Returns the state of the latest merge request...
  get-project-http-url  Get Gitlab project SSH URL (for cloning)
  get-project-ssh-url   Get Gitlab project SSH URL (for cloning)
  push                  Push commits from SOURCE_BRANCH to TARGET_BRANCH
  push-missing-tags     Push missing tags from a repository to another
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py get-latest-mr-state --help
Usage: main.py get-latest-mr-state [OPTIONS] SOURCE_BRANCH TARGET_BRANCH
                                   [LABELS]...

  Returns the state of the latest merge request between SOURCE_BRANCH and
  TARGET_BRANCH

Options:
  -r, --remote / -c, --current  Flag which allow you to chose between
                                configured target or remote to run this tool.
                                By default, the script use --current flag.
  --help                        Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py get-project-http-url --help
Usage: main.py get-project-http-url [OPTIONS]

  Get Gitlab project SSH URL (for cloning)

Options:
  -r, --remote / -c, --current  Flag which allow you to chose between
                                configured target or remote to run this tool.
                                By default, the script use --current flag.
  --help                        Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py get-project-ssh-url --help
Usage: main.py get-project-ssh-url [OPTIONS]

  Get Gitlab project SSH URL (for cloning)

Options:
  -r, --remote / -c, --current  Flag which allow you to chose between
                                configured target or remote to run this tool.
                                By default, the script use --current flag.
  --help                        Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py push --help
Usage: main.py push [OPTIONS] SOURCE_BRANCH TARGET_BRANCH

  Push commits from SOURCE_BRANCH to TARGET_BRANCH

  Args:     source_branch (str): source branch     target_branch (str):
  destination branch     from_gitlab (str, optional): source gitlab
  [current/remote]. Defaults to 'remote'.     to_gitlab (str, optional):
  destination gitlab [current/remote]. Defaults to 'remote'.     force (bool,
  optional): whether to force push. Defaults to False.

Options:
  -f, --from-gitlab [current|remote]
                                  Flag which allow you to chose between the
                                  current gitlab or the remote gitlab for the
                                  FROM role. Defaults to 'remote'.
  -t, --to-gitlab [current|remote]
                                  Flag which allow you to chose between the
                                  current gitlab or the remote gitlab for the
                                  TO role. Defaults to 'remote'.
  -f, --force                     Flag to enable force push
  --help                          Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py push --help
Usage: main.py push [OPTIONS] SOURCE_BRANCH TARGET_BRANCH

  Push commits from SOURCE_BRANCH to TARGET_BRANCH

Options:
  -f, --from-gitlab [current|remote]
                                  Flag which allow you to chose between the
                                  current gitlab or the remote gitlab for the
                                  FROM role. Defaults to 'remote'.
  -t, --to-gitlab [current|remote]
                                  Flag which allow you to chose between the
                                  current gitlab or the remote gitlab for the
                                  TO role. Defaults to 'remote'.
  -f, --force                     Flag to enable force push
  --help                          Show this message and exit.
```

```
(gitflow-toolbox-5VYMlFp_-py3.9) padeon@DESKTOP-UD0RTRK:~/spk/opensource/gitflow-toolbox$ python main.py push-missing-tags --help
Usage: main.py push-missing-tags [OPTIONS]

  Push missing tags from a repository to another

Options:
  -f, --from-gitlab [current|remote]
                                  Flag which allow you to chose between the
                                  current gitlab or the remote gitlab for the
                                  FROM role. Defaults to 'remote'.
  -t, --to-gitlab [current|remote]
                                  Flag which allow you to chose between the
                                  current gitlab or the remote gitlab for the
                                  TO role. Defaults to 'remote'.
  --help                          Show this message and exit.
```